### PR TITLE
Fix engines field location

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"
-    ],
-    "engines": {
-      "node": "18.x"
-    }
+    ]
+  },
+  "engines": {
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
## Summary
- move `engines` property to root of package.json

## Testing
- `node -e "console.log(require('./package.json').engines)"`
- ❌ `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_6887be47bd0c83278a0cf6bf226e0764